### PR TITLE
Dev/0.7.4 - support for SAS tokens in MSGEN

### DIFF
--- a/msgen_cli/malibuargs.py
+++ b/msgen_cli/malibuargs.py
@@ -242,8 +242,7 @@ def _get_parser(submit_func, list_func, cancel_func, status_func, help_func):
                                  help="Azure storage account name where input files reside")
     submit_required.add_argument("-ik", "--input-storage-account-key",
                                  metavar="KEY",
-                                 required=True,
-                                 type=malibuargsactions.nstr,
+                                 required=False,
                                  help="Azure storage account key which will be used to create temporary access tokens for input files")
     submit_required.add_argument("-ic", "--input-storage-account-container",
                                  metavar="CONTAINER",
@@ -255,13 +254,13 @@ def _get_parser(submit_func, list_func, cancel_func, status_func, help_func):
                                  required=True,
                                  type=malibuargsactions.input_validator,
                                  nargs="+",
-                                 help="first file name")
+                                 help="first file name; SAS can be appended")
     submit_required.add_argument("-b2", "--input-blob-name-2",
                                  metavar="BLOBNAME",
                                  required=False,
                                  type=malibuargsactions.input_validator,
                                  nargs="+",
-                                 help="second file name, needed only if input is in the FASTQ format")
+                                 help="second file name, needed only if input is in the FASTQ format; SAS can be appended")
     submit_required.add_argument("-oa", "--output-storage-account-name",
                                  metavar="ACCOUNT",
                                  required=True,
@@ -269,14 +268,13 @@ def _get_parser(submit_func, list_func, cancel_func, status_func, help_func):
                                  help="Azure storage account name where output files will be placed")
     submit_required.add_argument("-ok", "--output-storage-account-key",
                                  metavar="KEY",
-                                 required=True,
-                                 type=malibuargsactions.nstr,
+                                 required=False,
                                  help="Azure storage account key which will be used to create a temporary access token for an output container")
     submit_required.add_argument("-oc", "--output-storage-account-container",
                                  metavar="CONTAINER",
                                  required=True,
-                                 type=malibuargsactions.nstr,
-                                 help="Azure blob container where output files will be placed")
+                                 type=malibuargsactions.output_container_validator,
+                                 help="Azure blob container where output files will be placed; SAS can be appended")
 
     submit_optional = submit_parser.add_argument_group("optional arguments for submitting a workflow")
     submit_optional.add_argument("-p", "--process-name",

--- a/msgen_cli/malibuargs.py
+++ b/msgen_cli/malibuargs.py
@@ -232,7 +232,7 @@ def _get_parser(submit_func, list_func, cancel_func, status_func, help_func):
     submit_required.add_argument("-pa", "--process-args",
                                  metavar="ARGS",
                                  required=True,
-                                 type=malibuargsactions.nstr,
+                                 type=malibuargsactions.process_args_validator,
                                  help="""arguments for the genomics process; this is usually used to specify a desired reference genome, for example,
                                  'R=b37m1' or 'R=hg19m1' or 'R=hg38m1' or 'R=hg38m1x'""")
     submit_required.add_argument("-ia", "--input-storage-account-name",

--- a/msgen_cli/malibuargs.py
+++ b/msgen_cli/malibuargs.py
@@ -254,13 +254,13 @@ def _get_parser(submit_func, list_func, cancel_func, status_func, help_func):
                                  required=True,
                                  type=malibuargsactions.input_validator,
                                  nargs="+",
-                                 help="first file name; SAS can be appended")
+                                 help="first file name; SAS token can be appended")
     submit_required.add_argument("-b2", "--input-blob-name-2",
                                  metavar="BLOBNAME",
                                  required=False,
                                  type=malibuargsactions.input_validator,
                                  nargs="+",
-                                 help="second file name, needed only if input is in the FASTQ format; SAS can be appended")
+                                 help="second file name, needed only if input is in the FASTQ format; SAS token can be appended")
     submit_required.add_argument("-oa", "--output-storage-account-name",
                                  metavar="ACCOUNT",
                                  required=True,
@@ -274,7 +274,7 @@ def _get_parser(submit_func, list_func, cancel_func, status_func, help_func):
                                  metavar="CONTAINER",
                                  required=True,
                                  type=malibuargsactions.output_container_validator,
-                                 help="Azure blob container where output files will be placed; SAS can be appended")
+                                 help="Azure blob container where output files will be placed; SAS token can be appended")
 
     submit_optional = submit_parser.add_argument_group("optional arguments for submitting a workflow")
     submit_optional.add_argument("-p", "--process-name",

--- a/msgen_cli/malibuargsactions.py
+++ b/msgen_cli/malibuargsactions.py
@@ -172,21 +172,56 @@ def to_bool(value):
     raise argparse.ArgumentTypeError(error)
 
 BAD_BLOB_CHARS = re.compile("[^A-Za-z0-9._/-]")
-def _blob_name_validator(value):
+BAD_CONTAINER_CHARS = re.compile("[^A-Za-z0-9-]")
+BAD_SAS_CHARS = re.compile("[^A-Za-z0-9&?=%]")
+def _blob_name_validator(value, is_input = False):
     """Blob name validator based on regular expression"""
     # Name length 1-1024 (https://docs.microsoft.com/en-us/azure/guidance/guidance-naming-conventions#naming-rules-and-restrictions)
-    # Characters: alphanumeric, dot, dash, slash, and underscore
+    # Characters: alphanumeric, dot, dash, slash, and underscore.  
+
     value = value.strip()
     if not value:
         raise argparse.ArgumentTypeError("empty or whitespace-only names are not allowed; found [{}]".format(value))
     if len(value) > 1024:
         raise argparse.ArgumentTypeError("maximum length is 1024 characters; found a value of length {0}".format(len(value)))
-    if bool(BAD_BLOB_CHARS.search(value)):
-        error = "each name should only contain alphanumeric characters, dot, dash, underscore, and slash"
-        raise argparse.ArgumentTypeError(error + "; found [{0}]".format(value))
-    # We will not allow a leading slash in a blob name
     if value.startswith("/"):
         raise argparse.ArgumentTypeError("blob names cannot start with a slash; found [{0}]".format(value))
+    
+    blob_name_parts = value.split("?")   
+    blob_name_parts_count = len(blob_name_parts)
+
+    if bool(BAD_BLOB_CHARS.search(blob_name_parts[0])):
+        error = "each name should only contain alphanumeric characters, dot, hyphen, underscore, and slash"
+        raise argparse.ArgumentTypeError(error + "; found [{0}]".format(blob_name_parts[0]))
+    if is_input:
+        if blob_name_parts_count == 2:
+            if bool(BAD_SAS_CHARS.search(blob_name_parts[1])):
+                error = "each SAS should only contain alphanumeric characters, question mark, equals, percent, and ampersand"
+                raise argparse.ArgumentTypeError(error + "; found [{0}]".format(blob_name_parts[1]))
+        elif blob_name_parts_count > 2:
+            raise argparse.ArgumentTypeError("blob names cannot have more than one question market; found a value of length {0}".format(blob_name_parts_count)) 
+    else:
+        if blob_name_parts_count > 1:
+            raise argparse.ArgumentTypeError("output SAS can only be appended to the container name")
+
+    return value
+
+
+def _output_container_name_validator(value):
+    """Blob name validator based on regular expression"""   
+    container_name_parts = value.split("?")   
+    container_name_parts_count = len(container_name_parts)
+
+    if bool(BAD_BLOB_CHARS.search(container_name_parts[0])):
+        error = "container name should only contain alphanumeric characters and hyphens"
+        raise argparse.ArgumentTypeError(error + "; found [{0}]".format(container_name_parts[0]))
+    if container_name_parts_count == 2:
+        if bool(BAD_SAS_CHARS.search(container_name_parts[1])):
+            error = "each SAS should only contain question mark, alphanumeric characters, equals, percent, and ampersand"
+            raise argparse.ArgumentTypeError(error + "; found [{0}]".format(container_name_parts[1]))
+    elif container_name_parts_count > 2:
+        raise argparse.ArgumentTypeError("container names cannot have more than one question market; found a value of length {0}".format(container_name_parts_count)) 
+
     return value
 
 BAD_REFERENCE_CHARS = re.compile("[^A-Za-z0-9]")
@@ -214,13 +249,17 @@ def process_args_validator(value):
 
 def input_validator(value):
     """Input blob name validator"""
-    return _blob_name_validator(value)
+    return _blob_name_validator(value, True)
 
 def output_validator(value):
     """Output blob name validator"""
     if not value or not value.strip():
         return None
-    return _blob_name_validator(value.strip())
+    return _blob_name_validator(value.strip(), False)
+
+def output_container_validator(value):
+    """Output container name validator"""
+    return _output_container_name_validator(value)
 
 ALLOWED_READ_GROUP_CHARACTERS = set(string.letters + string.digits + string.punctuation + " \t") - set("=;")
 MAX_READ_GROUP_LENGTH = 1000
@@ -291,7 +330,16 @@ def validate_namespace(parser, namespace):
         namespace.input_blob_name_1 = []
     if not namespace.input_blob_name_2:
         namespace.input_blob_name_2 = []
-    all_blob_names = namespace.input_blob_name_1 + namespace.input_blob_name_2
+
+    # 0b. Only add blob names to the validation list (omit SAS)
+    all_blob_names = []
+    for blob_name in namespace.input_blob_name_1 + namespace.input_blob_name_2:
+        if "?" in blob_name:
+            blob_name_parts = blob_name.split("?")
+            all_blob_names.append(blob_name_parts[0])
+        else:
+            all_blob_names.append(blob_name)
+
     if len(all_blob_names) == 0:
         raise parser.error("no inputs provided")
 
@@ -308,6 +356,10 @@ def validate_namespace(parser, namespace):
             raise parser.error("each FASTQ file provided in -b1/--input-blob-name-1 should be paired with a FASTQ file in -b2/--input-blob-name-2 at the same position")
         # 3. If names in each pair don't match, show a warning
         for first, second in zip(namespace.input_blob_name_1, namespace.input_blob_name_2):
+            if "?" in first:
+                first = first.split("?")[0]
+            if "?" in second:
+                second = second.split("?")[0]
             if first == second:
                 raise parser.error("the same file is used at the same position in both -b1/--input-blob-name-1 and -b2/--input-blob-name-2: [{0}]".format(first))
             if not differ_in_at_most_one(first, second) and not namespace.suppress_fastq_validation:

--- a/msgen_cli/malibuargsactions.py
+++ b/msgen_cli/malibuargsactions.py
@@ -172,8 +172,7 @@ def to_bool(value):
     raise argparse.ArgumentTypeError(error)
 
 BAD_BLOB_CHARS = re.compile("[^A-Za-z0-9._/-]")
-BAD_CONTAINER_CHARS = re.compile("[^A-Za-z0-9-]")
-BAD_SAS_CHARS = re.compile("[^A-Za-z0-9&?=%]")
+BAD_SAS_CHARS = re.compile("[^A-Za-z0-9&?=%/-]")
 def _blob_name_validator(value, is_input = False):
     """Blob name validator based on regular expression"""
     # Name length 1-1024 (https://docs.microsoft.com/en-us/azure/guidance/guidance-naming-conventions#naming-rules-and-restrictions)
@@ -196,7 +195,7 @@ def _blob_name_validator(value, is_input = False):
     if is_input:
         if blob_name_parts_count == 2:
             if bool(BAD_SAS_CHARS.search(blob_name_parts[1])):
-                error = "each SAS should only contain alphanumeric characters, question mark, equals, percent, and ampersand"
+                error = "each SAS should only contain alphanumeric characters, question mark, equals, percent, slash, hyphen and ampersand"
                 raise argparse.ArgumentTypeError(error + "; found [{0}]".format(blob_name_parts[1]))
         elif blob_name_parts_count > 2:
             raise argparse.ArgumentTypeError("blob names cannot have more than one question market; found a value of length {0}".format(blob_name_parts_count)) 

--- a/msgen_cli/malibuargsactions.py
+++ b/msgen_cli/malibuargsactions.py
@@ -195,13 +195,13 @@ def _blob_name_validator(value, is_input = False):
     if is_input:
         if blob_name_parts_count == 2:
             if bool(BAD_SAS_CHARS.search(blob_name_parts[1])):
-                error = "each SAS should only contain alphanumeric characters, question mark, equals, percent, slash, hyphen and ampersand"
+                error = "each SAS token should only contain alphanumeric characters, question mark, equals, percent, slash, hyphen and ampersand"
                 raise argparse.ArgumentTypeError(error + "; found [{0}]".format(blob_name_parts[1]))
         elif blob_name_parts_count > 2:
             raise argparse.ArgumentTypeError("blob names cannot have more than one question market; found a value of length {0}".format(blob_name_parts_count)) 
     else:
         if blob_name_parts_count > 1:
-            raise argparse.ArgumentTypeError("output SAS can only be appended to the container name")
+            raise argparse.ArgumentTypeError("output SAS token can only be appended to the container name")
 
     return value
 
@@ -216,7 +216,7 @@ def _output_container_name_validator(value):
         raise argparse.ArgumentTypeError(error + "; found [{0}]".format(container_name_parts[0]))
     if container_name_parts_count == 2:
         if bool(BAD_SAS_CHARS.search(container_name_parts[1])):
-            error = "each SAS should only contain question mark, alphanumeric characters, equals, percent, and ampersand"
+            error = "each SAS token should only contain alphanumeric characters, question mark, equals, percent, slash, hyphen and ampersand"
             raise argparse.ArgumentTypeError(error + "; found [{0}]".format(container_name_parts[1]))
     elif container_name_parts_count > 2:
         raise argparse.ArgumentTypeError("container names cannot have more than one question market; found a value of length {0}".format(container_name_parts_count)) 
@@ -327,7 +327,7 @@ def validate_namespace(parser, namespace):
     if ((namespace.output_storage_account_key or namespace.input_storage_account_key) and 
         namespace.output_storage_account_container and 
         "?" in namespace.output_storage_account_container):
-        raise parser.error("cannot mix storage account key(s) and SAS.  You must only use keys, or only use SAS")
+        raise parser.error("cannot mix storage account keys and SAS tokens.  You must only use keys, or only use SAS tokens")
 
     # 0. Make sure we have something as input.
     if not namespace.input_blob_name_1:
@@ -340,7 +340,7 @@ def validate_namespace(parser, namespace):
     for blob_name in namespace.input_blob_name_1 + namespace.input_blob_name_2:
         if "?" in blob_name:
             if namespace.input_storage_account_key or namespace.output_storage_account_key:
-                raise parser.error("cannot mix storage account key(s) and SAS.  You must only use keys, or only use SAS")
+                raise parser.error("cannot mix storage account keys and SAS tokens.  You must only use keys, or only use SAS tokens")
             blob_name_parts = blob_name.split("?")
             all_blob_names.append(blob_name_parts[0])
         else:

--- a/msgen_cli/malibuargsactions.py
+++ b/msgen_cli/malibuargsactions.py
@@ -329,14 +329,28 @@ def validate_namespace(parser, namespace):
         "?" in namespace.output_storage_account_container):
         raise parser.error("cannot mix storage account keys and SAS tokens.  You must only use keys, or only use SAS tokens")
 
+    if (not namespace.output_storage_account_key and
+        (not namespace.output_storage_account_container or
+        "?" not in namespace.output_storage_account_container)):
+        raise parser.error("you must include either an output storage account key or output storage account container SAS token")
+
+
+    if (not namespace.output_storage_account_key and
+        (not namespace.output_storage_account_container or
+        "?" not in namespace.output_storage_account_container)):
+        raise parser.error("you must include either an output storage account key or output storage account container SAS token")
+
     # 0. Make sure we have something as input.
     if not namespace.input_blob_name_1:
         namespace.input_blob_name_1 = []
     if not namespace.input_blob_name_2:
         namespace.input_blob_name_2 = []
 
-    # 0b. Only add blob names to the validation list (omit SAS)
     all_blob_names = []
+    key_provided_for_blob = False
+    if namespace.input_storage_account_key:
+        key_provided_for_blob = True
+
     for blob_name in namespace.input_blob_name_1 + namespace.input_blob_name_2:
         if "?" in blob_name:
             if namespace.input_storage_account_key or namespace.output_storage_account_key:
@@ -344,6 +358,9 @@ def validate_namespace(parser, namespace):
             blob_name_parts = blob_name.split("?")
             all_blob_names.append(blob_name_parts[0])
         else:
+            if not key_provided_for_blob:
+                # no key and NO SAS token
+                raise parser.error("you must include either an input storage account key or blob SAS token(s)")
             all_blob_names.append(blob_name)
 
     if len(all_blob_names) == 0:

--- a/msgen_cli/malibuargsactions.py
+++ b/msgen_cli/malibuargsactions.py
@@ -172,7 +172,6 @@ def to_bool(value):
     raise argparse.ArgumentTypeError(error)
 
 BAD_BLOB_CHARS = re.compile("[^A-Za-z0-9._/-]")
-
 def _blob_name_validator(value):
     """Blob name validator based on regular expression"""
     # Name length 1-1024 (https://docs.microsoft.com/en-us/azure/guidance/guidance-naming-conventions#naming-rules-and-restrictions)
@@ -183,12 +182,35 @@ def _blob_name_validator(value):
     if len(value) > 1024:
         raise argparse.ArgumentTypeError("maximum length is 1024 characters; found a value of length {0}".format(len(value)))
     if bool(BAD_BLOB_CHARS.search(value)):
-        error = "each name should contain only alphanumeric characters, dot, dash, underscore, and slash"
+        error = "each name should only contain alphanumeric characters, dot, dash, underscore, and slash"
         raise argparse.ArgumentTypeError(error + "; found [{0}]".format(value))
     # We will not allow a leading slash in a blob name
     if value.startswith("/"):
         raise argparse.ArgumentTypeError("blob names cannot start with a slash; found [{0}]".format(value))
     return value
+
+BAD_REFERENCE_CHARS = re.compile("[^A-Za-z0-9]")
+ARG_DELIMITER = ";"
+KEY_VALUE_DELIMITER = "="
+def _process_args_validator(value):
+    """Process args validator \\"""
+    if not value or value is None:
+        raise argparse.ArgumentTypeError("a non-empty, non-whitespace string is expected")
+    value = value.strip()
+    if not value or value is None:
+        raise argparse.ArgumentTypeError("a non-empty, non-whitespace string is expected")
+    kv_pairs = value.split(ARG_DELIMITER)
+    for kv_pair in kv_pairs:
+        kv = kv_pair.split(KEY_VALUE_DELIMITER)
+        if kv[0]=="R":
+            if bool(BAD_REFERENCE_CHARS.search(kv[1])):
+                error = "the reference should only contain alphanumeric characters"
+                raise argparse.ArgumentTypeError(error + "; found [{0}]".format(value))
+    return value
+
+def process_args_validator(value):
+    """Process arguments validator"""
+    return _process_args_validator(value)
 
 def input_validator(value):
     """Input blob name validator"""

--- a/msgen_cli/malibuworkflow.py
+++ b/msgen_cli/malibuworkflow.py
@@ -328,26 +328,54 @@ class WorkflowExecutor(object):
                            self.datatransfer.input_container, False)
         for blob1, blob2 in izip_longest(self.args_output.input_blob_name_1, self.args_output.input_blob_name_2):
             if blob1:
-                self.add_key_value(input_dic, "BLOBNAMES", blob1, True)
-                self.add_key_value(input_dic,
-                                   "BLOBNAMES_WITH_SAS",
-                                   self.datatransfer.create_input_blob_sas_url(blob1, self.args_output.sas_duration),
-                                   True)
+                if "?" in blob1:
+                    # SAS token has been included in blobname
+                    blob_name_parts = blob1.split("?")  
+                    self.add_key_value(input_dic, "BLOBNAMES", blob_name_parts[0], True)
+                    self.add_key_value(input_dic,
+                                       "BLOBNAMES_WITH_SAS",
+                                       blob1,
+                                       True)
+                else:
+                    self.add_key_value(input_dic, "BLOBNAMES", blob1, True)
+                    self.add_key_value(input_dic,
+                                       "BLOBNAMES_WITH_SAS",
+                                       self.datatransfer.create_input_blob_sas_url(blob1, self.args_output.sas_duration),
+                                       True)
             if blob2:
-                self.add_key_value(input_dic, "BLOBNAMES", blob2, True)
-                self.add_key_value(input_dic,
-                                   "BLOBNAMES_WITH_SAS",
-                                   self.datatransfer.create_input_blob_sas_url(blob2, self.args_output.sas_duration),
-                                   True)
+                if "?" in blob2:
+                    # SAS token has been included in blobname
+                    blob_name_parts = blob2.split("?")  
+                    self.add_key_value(input_dic, "BLOBNAMES", blob_name_parts[0], True)
+                    self.add_key_value(input_dic,
+                                       "BLOBNAMES_WITH_SAS",
+                                       blob2,
+                                       True)
+                else:
+                    self.add_key_value(input_dic, "BLOBNAMES", blob2, True)
+                    self.add_key_value(input_dic,
+                                       "BLOBNAMES_WITH_SAS",
+                                       self.datatransfer.create_input_blob_sas_url(blob2, self.args_output.sas_duration),
+                                       True)
         output_dic = dict()
         self.add_key_value(output_dic, "ACCOUNT",
                            self.args_output.output_storage_account_name, False)
-        self.add_key_value(output_dic, "CONTAINER",
-                           self.datatransfer.output_container, False)
+
         self.add_key_value(output_dic, "OVERWRITE",
                            str(self.args_output.output_overwrite).lower(), False)
-        self.add_key_value(output_dic, "CONTAINER_SAS",
-                           self.datatransfer.create_output_sas(self.args_output.sas_duration), False)
+
+        if "?" in self.datatransfer.output_container:
+            # SAS token has been included in container
+            container_name_parts = self.datatransfer.output_container.split("?")  
+            self.add_key_value(output_dic, "CONTAINER",
+                               container_name_parts[0], False)
+            self.add_key_value(output_dic, "CONTAINER_SAS",
+                               self.datatransfer.output_container, False)
+        else:
+            self.add_key_value(output_dic, "CONTAINER",
+                               self.datatransfer.output_container, False)
+            self.add_key_value(output_dic, "CONTAINER_SAS",
+                               self.datatransfer.create_output_sas(self.args_output.sas_duration), False)
         self.add_key_value(output_dic, "OUTPUT_FILENAME_BASE",
                            self.args_output.output_filename_base, False)
         self.add_key_value(output_dic, "OUTPUT_INCLUDE_LOGFILES",

--- a/msgen_cli/msgen.py
+++ b/msgen_cli/msgen.py
@@ -17,7 +17,7 @@ import malibuargs
 # Version must be valid form for StrictVersion <d>.<d>.<d> for the sort
 # to work properly and find the latest version.  More details at:
 # http://epydoc.sourceforge.net/stdlib/distutils.version.StrictVersion-class.html
-VERSION = '0.7.3'
+VERSION = '0.7.4'
 
 def warn_for_package_update(current_version):
     """Check for updated version of msgen and warn if a newer version is available"""

--- a/tests/test_malibuargs.py
+++ b/tests/test_malibuargs.py
@@ -58,8 +58,20 @@ class TestParse(unittest.TestCase):
     def test_parse_runs_successfully_with_unmatching_fastq_names(self):
         argv = "submit -f tests/unittestconfig.txt".split()
         args = malibuargs.parse(argv + ["-b2", "file1.fq"], None, None, None, None, None)
-        self.assertListEqual(args.input_blob_name_1, ["chr21-10k_1.fq.gz"])
-        self.assertListEqual(args.input_blob_name_2, ["file1.fq"])
+        blobs1 = args.input_blob_name_1
+        blobs2 = args.input_blob_name_2
+        blobs1_parsed = []
+        blobs2_parsed = []
+        for blob in blobs1:
+            if "?" in blob:
+                blob = blob.split("?")[0]
+            blobs1_parsed.append(blob)
+        for blob in blobs2:
+            if "?" in blob:
+                blob = blob.split("?")[0]
+            blobs2_parsed.append(blob)
+        self.assertListEqual(blobs1_parsed, ["chr21-10k_1.fq.gz"])
+        self.assertListEqual(blobs2_parsed, ["file1.fq"])
 
     def test_parse_fails_when_command_missing(self):
         argv = "-f tests/unittestconfig.txt".split()

--- a/tests/test_malibuargs.py
+++ b/tests/test_malibuargs.py
@@ -51,27 +51,62 @@ class TestParse(unittest.TestCase):
 
     def test_parse_runs_successfully_with_uneven_bam(self):
         argv = "submit -f tests/unittestconfig.txt".split()
-        args = malibuargs.parse(argv + ["-b2", "file1.bam", "-b1", "file1.sam", "file2.sam"], None, None, None, None, None)
-        self.assertListEqual(args.input_blob_name_1, ["file1.sam", "file2.sam"])
-        self.assertListEqual(args.input_blob_name_2, ["file1.bam"])
+        using_key = False
+        with open("tests/unittestconfig.txt", 'r') as file:
+            for line in file:
+                if "input_storage_account_key" in line.lower():
+                    using_key = True
+                    break
+        if using_key:
+            args = malibuargs.parse(argv + ["-b2", "file1.bam", "-b1", "file1.sam", "file2.sam"], None, None, None, None, None)
+            self.assertListEqual(args.input_blob_name_1, ["file1.sam", "file2.sam"])
+            self.assertListEqual(args.input_blob_name_2, ["file1.bam"])
+        else:
+            args = malibuargs.parse(argv + ["-b2", "file1.bam?sas", "-b1", "file1.sam?sas", "file2.sam?sas"], None, None, None, None, None)
+            self.assertListEqual(args.input_blob_name_1, ["file1.sam?sas", "file2.sam?sas"])
+            self.assertListEqual(args.input_blob_name_2, ["file1.bam?sas"])
 
     def test_parse_runs_successfully_with_unmatching_fastq_names(self):
         argv = "submit -f tests/unittestconfig.txt".split()
-        args = malibuargs.parse(argv + ["-b2", "file1.fq"], None, None, None, None, None)
-        blobs1 = args.input_blob_name_1
-        blobs2 = args.input_blob_name_2
-        blobs1_parsed = []
-        blobs2_parsed = []
-        for blob in blobs1:
-            if "?" in blob:
-                blob = blob.split("?")[0]
-            blobs1_parsed.append(blob)
-        for blob in blobs2:
-            if "?" in blob:
-                blob = blob.split("?")[0]
-            blobs2_parsed.append(blob)
-        self.assertListEqual(blobs1_parsed, ["chr21-10k_1.fq.gz"])
-        self.assertListEqual(blobs2_parsed, ["file1.fq"])
+        using_key = False
+        with open("tests/unittestconfig.txt", 'r') as file:
+            for line in file:
+                if "input_storage_account_key" in line.lower():
+                    using_key = True
+                    break
+        if using_key:
+            args = malibuargs.parse(argv + ["-b2", "file1.fq"], None, None, None, None, None)
+            blobs1 = args.input_blob_name_1
+            blobs2 = args.input_blob_name_2
+            blobs1_parsed = []
+            blobs2_parsed = []
+            for blob in blobs1:
+                if "?" in blob:
+                    blob = blob.split("?")[0]
+                blobs1_parsed.append(blob)
+            for blob in blobs2:
+                if "?" in blob:
+                    blob = blob.split("?")[0]
+                blobs2_parsed.append(blob)
+            self.assertListEqual(blobs1_parsed, ["chr21-10k_1.fq.gz"])
+            self.assertListEqual(blobs2_parsed, ["file1.fq"])
+        else:
+            args = malibuargs.parse(argv + ["-b2", "file1.fq?sas"], None, None, None, None, None)
+            blobs1 = args.input_blob_name_1
+            blobs2 = args.input_blob_name_2
+            blobs1_parsed = []
+            blobs2_parsed = []
+            for blob in blobs1:
+                if "?" in blob:
+                    blob = blob.split("?")[0]
+                blobs1_parsed.append(blob)
+            for blob in blobs2:
+                if "?" in blob:
+                    blob = blob.split("?")[0]
+                blobs2_parsed.append(blob)
+            self.assertListEqual(blobs1_parsed, ["chr21-10k_1.fq.gz"])
+            self.assertListEqual(blobs2_parsed, ["file1.fq"])
+
 
     def test_parse_fails_when_command_missing(self):
         argv = "-f tests/unittestconfig.txt".split()

--- a/tests/test_malibuargsactions.py
+++ b/tests/test_malibuargsactions.py
@@ -365,5 +365,19 @@ class TestReadGroupValidator(unittest.TestCase):
         result = parser.parse_args(["--argument", "@RG\tID:lal ala\tSM:my sample"])
         self.assertEquals(result.argument, "@RG\\tID:lal ala\\tSM:my sample")
 
+
+class TestProcessArgsValidator(unittest.TestCase):
+    def test_throws_if_process_args_is_none(self):
+        parser = argparse.ArgumentParser(self)
+        parser.add_argument("--argument", type=malibuargsactions.process_args_validator)
+        with self.assertRaises(SystemExit):
+            result = parser.parse_args(["--argument", None])
+
+    def test_throws_if_bad_char_in_reference(self):
+        parser = argparse.ArgumentParser()
+        parser.add_argument("--argument", type=malibuargsactions.process_args_validator)
+        with self.assertRaises(SystemExit):
+            result = parser.parse_args(["--argument", "R=hg19m1-2"])
+
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_malibuworkflow.py
+++ b/tests/test_malibuworkflow.py
@@ -312,7 +312,25 @@ class TestMalibuWorkflow(unittest.TestCase):
         inputs, outputs = workflow.get_input_and_output_dict()
         self.assertEquals(inputs["BLOBNAMES"], "file.bam,")
 
+    def test_get_input_output_dict_handles_one_file_with_sas(self):
+        args = testargs.get_test_args()
+        args.input_blob_name_1 = ["file.bam?sas"]
+        args.input_blob_name_2 = []
+        workflow = malibuworkflow.WorkflowExecutor(args)
+        workflow.datatransfer = FakeDataTransfer(None)
+
+        inputs, outputs = workflow.get_input_and_output_dict()
+        self.assertEquals(inputs["BLOBNAMES"], "file.bam,")
+
     def test_get_input_output_dict_handles_two_files(self):
+        args = testargs.get_test_args()       
+        workflow = malibuworkflow.WorkflowExecutor(args)
+        workflow.datatransfer = FakeDataTransfer(None)
+
+        inputs, outputs = workflow.get_input_and_output_dict()
+        self.assertEquals(inputs["BLOBNAMES"], "chr21-10k_1.fq.gz,chr21-10k_2.fq.gz,")
+
+    def test_get_input_output_dict_handles_two_files_with_sas(self):
         args = testargs.get_test_args()       
         workflow = malibuworkflow.WorkflowExecutor(args)
         workflow.datatransfer = FakeDataTransfer(None)
@@ -324,6 +342,17 @@ class TestMalibuWorkflow(unittest.TestCase):
         args = testargs.get_test_args()
         args.input_blob_name_1 = ["chr21-10k_1.fq.gz", "chr22-10k_1.fq.gz"]
         args.input_blob_name_2 = ["chr21-10k_2.fq.gz", "chr22-10k_2.fq.gz"]
+        workflow = malibuworkflow.WorkflowExecutor(args)
+        workflow.datatransfer = FakeDataTransfer(None)
+
+        inputs, outputs = workflow.get_input_and_output_dict()
+        self.assertEquals(inputs["BLOBNAMES"], "chr21-10k_1.fq.gz,chr21-10k_2.fq.gz,chr22-10k_1.fq.gz,chr22-10k_2.fq.gz,")
+
+
+    def test_get_input_output_dict_handles_multiple_files_with_sas(self):
+        args = testargs.get_test_args()
+        args.input_blob_name_1 = ["chr21-10k_1.fq.gz?sas", "chr22-10k_1.fq.gz?sas"]
+        args.input_blob_name_2 = ["chr21-10k_2.fq.gz?sas", "chr22-10k_2.fq.gz?sas"]
         workflow = malibuworkflow.WorkflowExecutor(args)
         workflow.datatransfer = FakeDataTransfer(None)
 


### PR DESCRIPTION
This adds support for SAS tokens to be specified as part of input blob name(s) or the output storage account container (example below).  Please note that mixing keys and SAS tokens is NOT supported - you must only use keys (input_storage_account_key and output_storage_account_key), or must only use SAS tokens (like below).

input_blob_name_1:			        chr21-10k_1.fq.gz?sas
input_blob_name_2:		            chr21-10k_2.fq.gz?sas
output_storage_account_container:	unittest1?sas